### PR TITLE
Fix test teardown

### DIFF
--- a/datasource_test.go
+++ b/datasource_test.go
@@ -127,5 +127,7 @@ func TestDatasource(t *testing.T) {
 	}
 
 	// Teardown de la BD de test
-	os.Remove("test.db")
+	if config.DatabaseDriver == "sqlite3" {
+		os.Remove(config.ConnectionString)
+	}
 }


### PR DESCRIPTION
Mini fix qui enlève une valeur hardcoded lors du teardown des tests de la datasource